### PR TITLE
Use docstrings and ignore egg-info.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 *.exe
 *.o
 *.so
+*.egg-info
+.vscode
 
 # Packages #
 ############

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,8 @@
-#SPDX-License-Identifier: MIT
+'''
+SPDX-License-Identifier: MIT
+
+Install ghdata package with pip.
+'''
 
 from setuptools import setup, find_packages
 from codecs import open


### PR DESCRIPTION
Uses docstrings for setup.py documentation and adds a couple entries to .gitignore.